### PR TITLE
Feat/generate fb message

### DIFF
--- a/lib/bot-builder.js
+++ b/lib/bot-builder.js
@@ -5,6 +5,7 @@ const fbSetup = require('./facebook/setup');
 const slackSetup = require('./slack/setup');
 const telegramSetup = require('./telegram/setup');
 const skypeSetup = require('./skype/setup');
+const formatFbMessage = require('./facebook/format-message');
 
 let logError = function (err) {
   console.error(err);
@@ -27,3 +28,5 @@ module.exports = function botBuilder(messageHandler, optionalLogError) {
 
   return api;
 };
+
+module.exports.formatFbMessage = formatFbMessage;

--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -5,7 +5,26 @@ function isUrl(url) {
   return pattern.test(url);
 }
 
-function image() {}
+class image {
+  constructor(url) {
+    if (!url || !isUrl(url))
+      throw new Error('Image template requires a valid URL as a first paramether');
+
+    this.url = url;
+  }
+
+  get() {
+    if (!this.url || !isUrl(this.url))
+      throw new Error('Image template requires a valid URL as a first paramether');
+
+    return {
+      attachment: {
+        type: 'image',
+        url: this.url
+      }
+    };
+  }
+}
 
 function generic() {
   this.bubbles = [];

--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -1,0 +1,116 @@
+'use strict';
+
+module.exports = {
+  image: image,
+  generic: generic,
+  button: button,
+  receipt: receipt
+};
+
+function isUrl(url) {
+  return !!url;
+}
+
+function image() {}
+
+function generic() {
+  this.elements = [];
+}
+
+function getLastBubble(bubbles) {
+  return bubbles.length[bubbles.length - 1];
+}
+
+generic.prototype.addBubble = function(title, subtitle) {
+  if (this.arr.length === 10)
+    throw new Error('10 bubbles are maximum for Generic template');
+
+  if (!title)
+    throw new Error('Bubble title cannot be empty');
+
+  if (title.length > 80)
+    throw new Error('Button title cannot be longer than 80 characters');
+
+  if (subtitle && subtitle.length > 80)
+    throw new Error('Button subtitle cannot be longer than 80 characters');
+
+  this.arr.push({
+    title: title,
+    subtitle: subtitle
+  });
+
+  return this;
+};
+
+generic.prototype.addUrl = function(url) {
+  if (!url)
+    throw new Error('URL is required for addUrl method');
+
+  if (!isUrl(url))
+    throw new Error('URL needs to be valid for addUrl method');
+
+  getLastBubble(this.bubbles)['item_url'] = url;
+
+  return this;
+};
+
+generic.prototype.addImage = function(url) {
+  if (!url)
+    throw new Error('Image URL is required for addImage method');
+
+  if (!isUrl(url))
+    throw new Error('Image URL needs to be valid for addImage method');
+
+  getLastBubble(this.bubbles)['image_url'] = url;
+
+  return this;
+};
+
+generic.prototype.addButton = function(title, value) {
+  const bubble = getLastBubble(this.bubbles);
+
+  if (bubble.buttons.length === 3)
+    throw new Error('3 buttons are already added and that\'s the maximum');
+
+  if (!title)
+    throw new Error('Button title cannot be empty');
+
+  if (!value)
+    throw new Error('Bubble value is required');
+
+  const button = {
+    title: title
+  };
+
+  if (isUrl(value)) {
+    button.type = 'web_url';
+    button.url = value;
+  } else {
+    button.type = 'postback';
+    button.payload = value;
+  }
+
+  bubble.buttons.push(button);
+
+  return this;
+};
+
+generic.prototype.get = function() {
+  return {
+    recipient: {},
+    message: {
+      attachment: {
+        type: 'template',
+        payload: {
+          template_type: 'generic',
+          elements: this.bubbles
+        }
+      }
+    },
+    notification_type: this.notificationType || 'REGULAR'
+  };
+};
+
+function button() {}
+
+function receipt() {}

--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -30,111 +30,113 @@ class image {
   }
 }
 
-function generic() {
-  this.bubbles = [];
-}
-
-generic.prototype.getLastBubble = function() {
-  if (!this.bubbles || !this.bubbles.length)
-    throw new Error('Add at least one bubble first!');
-
-  return this.bubbles[this.bubbles.length - 1];
-};
-
-generic.prototype.addBubble = function(title, subtitle) {
-  if (this.bubbles.length === 10)
-    throw new Error('10 bubbles are maximum for Generic template');
-
-  if (!title)
-    throw new Error('Bubble title cannot be empty');
-
-  if (title.length > 80)
-    throw new Error('Bubble title cannot be longer than 80 characters');
-
-  if (subtitle && subtitle.length > 80)
-    throw new Error('Bubble subtitle cannot be longer than 80 characters');
-
-  let bubble = {
-    title: title
-  };
-
-  if (subtitle)
-    bubble['subtitle'] = subtitle;
-
-  this.bubbles.push(bubble);
-
-  return this;
-};
-
-generic.prototype.addUrl = function(url) {
-  if (!url)
-    throw new Error('URL is required for addUrl method');
-
-  if (!isUrl(url))
-    throw new Error('URL needs to be valid for addUrl method');
-
-  this.getLastBubble()['item_url'] = url;
-
-  return this;
-};
-
-generic.prototype.addImage = function(url) {
-  if (!url)
-    throw new Error('Image URL is required for addImage method');
-
-  if (!isUrl(url))
-    throw new Error('Image URL needs to be valid for addImage method');
-
-  this.getLastBubble()['image_url'] = url;
-
-  return this;
-};
-
-generic.prototype.addButton = function(title, value) {
-  const bubble = this.getLastBubble();
-
-  bubble.buttons = bubble.buttons || [];
-
-  if (bubble.buttons.length === 3)
-    throw new Error('3 buttons are already added and that\'s the maximum');
-
-  if (!title)
-    throw new Error('Button title cannot be empty');
-
-  if (!value)
-    throw new Error('Bubble value is required');
-
-  const button = {
-    title: title
-  };
-
-  if (isUrl(value)) {
-    button.type = 'web_url';
-    button.url = value;
-  } else {
-    button.type = 'postback';
-    button.payload = value;
+class generic{
+  constructor() {
+    this.bubbles = [];
   }
 
-  bubble.buttons.push(button);
+  getLastBubble() {
+    if (!this.bubbles || !this.bubbles.length)
+      throw new Error('Add at least one bubble first!');
 
-  return this;
-};
+    return this.bubbles[this.bubbles.length - 1];
+  }
 
-generic.prototype.get = function() {
-  if (!this.bubbles || !this.bubbles.length)
-    throw new Error('Add at least one bubble first!');
+  addBubble(title, subtitle) {
+    if (this.bubbles.length === 10)
+      throw new Error('10 bubbles are maximum for Generic template');
 
-  return {
-    attachment: {
-      type: 'template',
-      payload: {
-        template_type: 'generic',
-        elements: this.bubbles
-      }
+    if (!title)
+      throw new Error('Bubble title cannot be empty');
+
+    if (title.length > 80)
+      throw new Error('Bubble title cannot be longer than 80 characters');
+
+    if (subtitle && subtitle.length > 80)
+      throw new Error('Bubble subtitle cannot be longer than 80 characters');
+
+    let bubble = {
+      title: title
+    };
+
+    if (subtitle)
+      bubble['subtitle'] = subtitle;
+
+    this.bubbles.push(bubble);
+
+    return this;
+  }
+
+  addUrl(url) {
+    if (!url)
+      throw new Error('URL is required for addUrl method');
+
+    if (!isUrl(url))
+      throw new Error('URL needs to be valid for addUrl method');
+
+    this.getLastBubble()['item_url'] = url;
+
+    return this;
+  }
+
+  addImage(url) {
+    if (!url)
+      throw new Error('Image URL is required for addImage method');
+
+    if (!isUrl(url))
+      throw new Error('Image URL needs to be valid for addImage method');
+
+    this.getLastBubble()['image_url'] = url;
+
+    return this;
+  }
+
+  addButton(title, value) {
+    const bubble = this.getLastBubble();
+
+    bubble.buttons = bubble.buttons || [];
+
+    if (bubble.buttons.length === 3)
+      throw new Error('3 buttons are already added and that\'s the maximum');
+
+    if (!title)
+      throw new Error('Button title cannot be empty');
+
+    if (!value)
+      throw new Error('Bubble value is required');
+
+    const button = {
+      title: title
+    };
+
+    if (isUrl(value)) {
+      button.type = 'web_url';
+      button.url = value;
+    } else {
+      button.type = 'postback';
+      button.payload = value;
     }
-  };
-};
+
+    bubble.buttons.push(button);
+
+    return this;
+  }
+
+  get() {
+    if (!this.bubbles || !this.bubbles.length)
+      throw new Error('Add at least one bubble first!');
+
+    return {
+      attachment: {
+        type: 'template',
+        payload: {
+          template_type: 'generic',
+          elements: this.bubbles
+        }
+      }
+    };
+  }
+}
 
 class button {
   constructor(text) {

--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -21,30 +21,37 @@ function isUrl(url) {
 function image() {}
 
 function generic() {
-  this.elements = [];
+  this.bubbles = [];
 }
 
 function getLastBubble(bubbles) {
+  if (!bubbles || !bubbles.length)
+    throw new Error('Add at least one bubble first!');
+
   return bubbles.length[bubbles.length - 1];
 }
 
 generic.prototype.addBubble = function(title, subtitle) {
-  if (this.arr.length === 10)
+  if (this.bubbles.length === 10)
     throw new Error('10 bubbles are maximum for Generic template');
 
   if (!title)
     throw new Error('Bubble title cannot be empty');
 
   if (title.length > 80)
-    throw new Error('Button title cannot be longer than 80 characters');
+    throw new Error('Bubble title cannot be longer than 80 characters');
 
   if (subtitle && subtitle.length > 80)
-    throw new Error('Button subtitle cannot be longer than 80 characters');
+    throw new Error('Bubble subtitle cannot be longer than 80 characters');
 
-  this.arr.push({
-    title: title,
-    subtitle: subtitle
-  });
+  let bubble = {
+    title: title
+  };
+
+  if (subtitle)
+    bubble['subtitle'] = subtitle;
+
+  this.bubbles.push(bubble);
 
   return this;
 };
@@ -103,6 +110,9 @@ generic.prototype.addButton = function(title, value) {
 };
 
 generic.prototype.get = function() {
+  if (!this.bubbles || !this.bubbles.length)
+    throw new Error('Add at least one bubble first!');
+
   return {
     attachment: {
       type: 'template',

--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -1,12 +1,5 @@
 'use strict';
 
-module.exports = {
-  image: image,
-  generic: generic,
-  button: button,
-  receipt: receipt
-};
-
 function isUrl(url) {
   const pattern = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
   return pattern.test(url);
@@ -120,6 +113,67 @@ generic.prototype.get = function() {
   };
 };
 
-function button() {}
+class button {
+  constructor(text) {
+    if (!text)
+      throw new Error('Button template text cannot be empty');
+
+    if (text.length > 80)
+      throw new Error('Button template text cannot be longer than 80 characters');
+
+    this.text = text;
+    this.buttons = [];
+  }
+
+  addButton(title, value) {
+    if (this.buttons.length === 3)
+      throw new Error('3 buttons are already added and that\'s the maximum');
+
+    if (!title)
+      throw new Error('Button title cannot be empty');
+
+    if (!value)
+      throw new Error('Bubble value is required');
+
+    const button = {
+      title: title
+    };
+
+    if (isUrl(value)) {
+      button.type = 'web_url';
+      button.url = value;
+    } else {
+      button.type = 'postback';
+      button.payload = value;
+    }
+
+    this.buttons.push(button);
+
+    return this;
+  }
+
+  get() {
+    if (!this.buttons.length)
+      throw new Error('Add at least one button first!');
+
+    return {
+      attachment: {
+        type: 'template',
+        payload: {
+          template_type: 'button',
+          text: this.text,
+          buttons: this.buttons
+        }
+      }
+    };
+  }
+}
 
 function receipt() {}
+
+module.exports = {
+  image: image,
+  generic: generic,
+  button: button,
+  receipt: receipt
+};

--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -8,14 +8,8 @@ module.exports = {
 };
 
 function isUrl(url) {
-  const patterns = {
-    protocol: '^(http(s)?(:\/\/))?(www\.)?',
-    domain: '[a-zA-Z0-9-_\.]+',
-    tld: '(\.[a-zA-Z0-9]{2,})',
-    params: '([-a-zA-Z0-9:%_\+.~#?&//=]*)'
-  };
-  var pattern = new RegExp(patterns.protocol + patterns.domain + patterns.tld + patterns.params, 'gi');
-  return pattern.exec(url);
+  const pattern = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
+  return pattern.test(url);
 }
 
 function image() {}
@@ -24,12 +18,12 @@ function generic() {
   this.bubbles = [];
 }
 
-function getLastBubble(bubbles) {
-  if (!bubbles || !bubbles.length)
+generic.prototype.getLastBubble = function() {
+  if (!this.bubbles || !this.bubbles.length)
     throw new Error('Add at least one bubble first!');
 
-  return bubbles.length[bubbles.length - 1];
-}
+  return this.bubbles[this.bubbles.length - 1];
+};
 
 generic.prototype.addBubble = function(title, subtitle) {
   if (this.bubbles.length === 10)
@@ -63,7 +57,7 @@ generic.prototype.addUrl = function(url) {
   if (!isUrl(url))
     throw new Error('URL needs to be valid for addUrl method');
 
-  getLastBubble(this.bubbles)['item_url'] = url;
+  this.getLastBubble()['item_url'] = url;
 
   return this;
 };
@@ -75,13 +69,15 @@ generic.prototype.addImage = function(url) {
   if (!isUrl(url))
     throw new Error('Image URL needs to be valid for addImage method');
 
-  getLastBubble(this.bubbles)['image_url'] = url;
+  this.getLastBubble()['image_url'] = url;
 
   return this;
 };
 
 generic.prototype.addButton = function(title, value) {
-  const bubble = getLastBubble(this.bubbles);
+  const bubble = this.getLastBubble();
+
+  bubble.buttons = bubble.buttons || [];
 
   if (bubble.buttons.length === 3)
     throw new Error('3 buttons are already added and that\'s the maximum');

--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -8,7 +8,14 @@ module.exports = {
 };
 
 function isUrl(url) {
-  return !!url;
+  const patterns = {
+    protocol: '^(http(s)?(:\/\/))?(www\.)?',
+    domain: '[a-zA-Z0-9-_\.]+',
+    tld: '(\.[a-zA-Z0-9]{2,})',
+    params: '([-a-zA-Z0-9:%_\+.~#?&//=]*)'
+  };
+  var pattern = new RegExp(patterns.protocol + patterns.domain + patterns.tld + patterns.params, 'gi');
+  return pattern.exec(url);
 }
 
 function image() {}
@@ -97,17 +104,13 @@ generic.prototype.addButton = function(title, value) {
 
 generic.prototype.get = function() {
   return {
-    recipient: {},
-    message: {
-      attachment: {
-        type: 'template',
-        payload: {
-          template_type: 'generic',
-          elements: this.bubbles
-        }
+    attachment: {
+      type: 'template',
+      payload: {
+        template_type: 'generic',
+        elements: this.bubbles
       }
-    },
-    notification_type: this.notificationType || 'REGULAR'
+    }
   };
 };
 

--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -5,6 +5,10 @@ function isUrl(url) {
   return pattern.test(url);
 }
 
+function isNumber(number) {
+  return !isNaN(parseFloat(number)) && isFinite(number);
+}
+
 class image {
   constructor(url) {
     if (!url || !isUrl(url))
@@ -188,7 +192,252 @@ class button {
   }
 }
 
-function receipt() {}
+class receipt{
+  constructor(name, orderNumber, currency, paymentMethod) {
+    if (!name)
+      throw new Error('Recipient\'s name cannot be empty');
+
+    if (!orderNumber)
+      throw new Error('Order number cannot be empty');
+
+    if (!currency)
+      throw new Error('Currency cannot be empty');
+
+    if (!paymentMethod)
+      throw new Error('Payment method cannot be empty');
+
+    this.output = {};
+
+    this.output.recipient_name = name;
+    this.output.order_number = orderNumber;
+    this.output.currency = currency;
+    this.output.payment_method = paymentMethod;
+    this.output.elements = [];
+    this.output.summary = {};
+  }
+
+  addTimestamp(timestamp) {
+    if (!timestamp)
+      throw new Error('Timestamp is required for addTimestamp method');
+
+    if (!(timestamp instanceof Date))
+      throw new Error('Timestamp needs to be a valid Date object');
+
+    this.output.timestamp = timestamp.getTime();
+
+    return this;
+  }
+
+  addOrderUrl(url) {
+    if (!url)
+      throw new Error('Url is required for addOrderUrl method');
+
+    if (!isUrl(url))
+      throw new Error('Url needs to be valid for addOrderUrl method');
+
+    this.output.order_url = url;
+
+    return this;
+  }
+
+  getLastItem() {
+    if (!this.output.elements || !this.output.elements.length)
+      throw new Error('Add at least one order item first!');
+
+    return this.output.elements[this.output.elements.length - 1];
+  }
+
+  addItem(title) {
+    if (!title)
+      throw new Error('Item title is required');
+
+    this.output.elements.push({
+      title: title
+    });
+
+    return this;
+  }
+
+  addSubtitle(subtitle) {
+    if (!subtitle)
+      throw new Error('Subtitle is required for addSubtitle method');
+
+    let item = this.getLastItem();
+
+    item.subtitle = subtitle;
+
+    return this;
+  }
+
+  addQuantity(quantity) {
+    if (!quantity)
+      throw new Error('Quantity is required for addQuantity method');
+
+    if (!isNumber(quantity))
+      throw new Error('Quantity needs to be a number');
+
+    let item = this.getLastItem();
+
+    item.quantity = quantity;
+
+    return this;
+  }
+
+  addPrice(price) {
+    if (!price)
+      throw new Error('Price is required for addPrice method');
+
+    if (!isNumber(price))
+      throw new Error('Price needs to be a number');
+
+    let item = this.getLastItem();
+
+    item.price = price;
+
+    return this;
+  }
+
+  addCurrency(currency) {
+    if (!currency)
+      throw new Error('Currency is required for addCurrency method');
+
+    let item = this.getLastItem();
+
+    item.currency = currency;
+
+    return this;
+  }
+
+  addImage(image) {
+    if (!image)
+      throw new Error('Url is required for addImage method');
+
+    if (!isUrl(image))
+      throw new Error('Valid url is required for addImage method');
+
+    let item = this.getLastItem();
+
+    item.image_url = image;
+
+    return this;
+  }
+
+  addShippingAddress(street1, street2, city, zip, state, country) {
+    if (!street1)
+      throw new Error('Street is required for addShippingAddress');
+
+    if (!city)
+      throw new Error('City is required for addShippingAddress method');
+
+    if (!zip)
+      throw new Error('Zip code is required for addShippingAddress method');
+
+    if (!state)
+      throw new Error('State is required for addShippingAddress method');
+
+    if (!country)
+      throw new Error('Country is required for addShippingAddress method');
+
+    this.output.address = {
+      street_1: street1,
+      city: city,
+      postal_code: zip,
+      state: state,
+      country: country
+    };
+
+    if (street2)
+      this.output.address.street_2 = street2;
+
+    return this;
+  }
+
+  addAdjustment(name, amount) {
+    if (amount && isNumber(amount))
+      throw new Error('Adjustment amount must be a number');
+
+    let adjustment = {};
+
+    if (name)
+      adjustment.name = name;
+
+    if (amount)
+      adjustment.amount = amount;
+
+    if (name || amount) {
+      this.output.adjustments = this.output.adjustments || [];
+      this.output.adjustments.push(adjustment);
+    }
+
+    return this;
+  }
+
+  addSubtotal(subtotal) {
+    if (!subtotal)
+      throw new Error('Subtotal is required for addSubtotal method');
+
+    if (!isNumber(subtotal))
+      throw new Error('Subtotal must be a number');
+
+    this.output.summary.subtotal = subtotal;
+
+    return this;
+  }
+
+  addShippingCost(shippingCost) {
+    if (!shippingCost)
+      throw new Error('shippingCost is required for addShippingCost method');
+
+    if (!isNumber(shippingCost))
+      throw new Error('Shipping cost must be a number');
+
+    this.output.summary.shipping_cost = shippingCost;
+
+    return this;
+  }
+
+  addTax(tax) {
+    if (!tax)
+      throw new Error('Total tax amount is required for addSubtotal method');
+
+    if (!isNumber(tax))
+      throw new Error('Total tax amount must be a number');
+
+    this.output.summary.total_tax = tax;
+
+    return this;
+  }
+
+  addTotal(total) {
+    if (!total)
+      throw new Error('Total amount is required for addSubtotal method');
+
+    if (!isNumber(total))
+      throw new Error('Total amount must be a number');
+
+    this.output.summary.total_amount = total;
+
+    return this;
+  }
+
+  get() {
+    if (!this.output.elements.length)
+      throw new Error('At least one element/item is required');
+
+    if (!this.output.summary.total_amount)
+      throw new Error('Total amount is required');
+
+    let payload = this.output;
+    payload.template_type = 'receipt';
+
+    return {
+      attachment: {
+        type: 'template',
+        payload: payload
+      }
+    };
+  }
+}
 
 module.exports = {
   image: image,

--- a/spec/facebook/facebook-format-message-spec.js
+++ b/spec/facebook/facebook-format-message-spec.js
@@ -36,6 +36,134 @@ describe('Facebook format message', () => {
       expect(() => generic.addBubble('Test', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua')).toThrowError('Bubble subtitle cannot be longer than 80 characters');
     });
 
+    it('should add a bubble with a provided title', () => {
+      generic.addBubble('Test');
+
+      expect(generic.bubbles.length).toBe(1);
+      expect(generic.bubbles[0].title).toBe('Test');
+    });
+
+    it('should add a bubble with a provided title and subtitle', () => {
+      generic.addBubble('Test Title', 'Test Subtitle');
+
+      expect(generic.bubbles.length).toBe(1);
+      expect(generic.bubbles[0].title).toBe('Test Title');
+      expect(generic.bubbles[0].subtitle).toBe('Test Subtitle');
+    });
+
+    it('should throw an error if you try to add an url but not provide it', () => {
+      generic
+        .addBubble('Test');
+
+      expect(() => generic.addUrl()).toThrowError('URL is required for addUrl method');
+    });
+
+    it('should throw an error if you try to add an url in invalid format', () => {
+      generic
+        .addBubble('Test');
+
+      expect(() => generic.addUrl('http//invalid-url')).toThrowError('URL needs to be valid for addUrl method');
+    });
+
+    it('should add an url if it is valid', () => {
+      generic
+        .addBubble('Test')
+        .addUrl('http://google.com');
+
+      expect(generic.bubbles.length).toBe(1);
+      expect(generic.bubbles[0].item_url).toBe('http://google.com');
+    });
+
+    it('should throw an error if you try to add an image but not provide an url', () => {
+      generic
+        .addBubble('Test');
+
+      expect(() => generic.addImage()).toThrowError('Image URL is required for addImage method');
+    });
+
+    it('should throw an error if you try to add an image, but url is in invalid format', () => {
+      generic
+        .addBubble('Test');
+
+      expect(() => generic.addImage('http//invalid-url')).toThrowError('Image URL needs to be valid for addImage method');
+    });
+
+    it('should add an url if it is valid', () => {
+      generic
+        .addBubble('Test')
+        .addUrl('http://google.com/path/to/image.png');
+
+      expect(generic.bubbles.length).toBe(1);
+      expect(generic.bubbles[0].item_url).toBe('http://google.com/path/to/image.png');
+    });
+
+    it('should throw an error if you add a button without the title', () => {
+      generic
+        .addBubble('Test');
+
+      expect(() => generic.addButton()).toThrowError('Button title cannot be empty');
+    });
+
+    it('should throw an error if you add a button without the value', () => {
+      generic
+        .addBubble('Test');
+
+      expect(() => generic.addButton('Title')).toThrowError('Bubble value is required');
+    });
+
+    it('should add a button with title and payload if you pass valid format', () => {
+      generic
+        .addBubble('Test')
+        .addButton('Title 1', 1);
+
+      expect(generic.bubbles[0].buttons.length).toBe(1);
+      expect(generic.bubbles[0].buttons[0].title).toBe('Title 1');
+      expect(generic.bubbles[0].buttons[0].type).toBe('postback');
+      expect(generic.bubbles[0].buttons[0].payload).toBe(1);
+      expect(generic.bubbles[0].buttons[0].url).not.toBeDefined();
+    });
+
+    it('should add a button with title and payload if you pass valid format', () => {
+      generic
+        .addBubble('Test')
+        .addButton('Title 1', 'http://google.com');
+
+      expect(generic.bubbles[0].buttons.length).toBe(1);
+      expect(generic.bubbles[0].buttons[0].title).toBe('Title 1');
+      expect(generic.bubbles[0].buttons[0].type).toBe('web_url');
+      expect(generic.bubbles[0].buttons[0].url).toBe('http://google.com');
+      expect(generic.bubbles[0].buttons[0].payload).not.toBeDefined();
+    });
+
+    it('should add 3 buttons with valid titles and formats', () => {
+      generic
+        .addBubble('Test')
+        .addButton('b1', 'v1')
+        .addButton('b2', 'v2')
+        .addButton('b3', 'v3');
+
+      expect(generic.bubbles[0].buttons.length).toBe(3);
+      expect(generic.bubbles[0].buttons[0].title).toBe('b1');
+      expect(generic.bubbles[0].buttons[0].payload).toBe('v1');
+      expect(generic.bubbles[0].buttons[1].title).toBe('b2');
+      expect(generic.bubbles[0].buttons[1].payload).toBe('v2');
+      expect(generic.bubbles[0].buttons[2].title).toBe('b3');
+      expect(generic.bubbles[0].buttons[2].payload).toBe('v3');
+    });
+
+    it('should throw an error if you add more than 3 buttons', () => {
+      generic
+        .addBubble('Test');
+
+      expect(() => {
+        generic
+          .addButton('Title 1', 1)
+          .addButton('Title 2', 2)
+          .addButton('Title 3', 3)
+          .addButton('Title 4', 4);
+      }).toThrowError('3 buttons are already added and that\'s the maximum');
+    });
+
     it('should throw an error if there\'s more than 10 bubbles', () => {
       expect(() =>
         generic
@@ -52,6 +180,24 @@ describe('Facebook format message', () => {
           .addBubble('11', 'hello')
       )
       .toThrowError('10 bubbles are maximum for Generic template');
+    });
+
+    it('should return a formated object in the end', () => {
+      expect(
+        generic
+          .addBubble('Title')
+          .get()
+      ).toEqual({
+        attachment: {
+          type: 'template',
+          payload: {
+            template_type: 'generic',
+            elements: [{
+              title: 'Title'
+            }]
+          }
+        }
+      });
     });
   });
 

--- a/spec/facebook/facebook-format-message-spec.js
+++ b/spec/facebook/facebook-format-message-spec.js
@@ -1,0 +1,69 @@
+/*global describe, xdescribe, it, expect, beforeEach, require */
+'use strict';
+
+const formatFbMessage = require('../../lib/facebook/format-message');
+
+describe('Facebook format message', () => {
+  it('should export an object', () => {
+    expect(typeof formatFbMessage).toBe('object');
+  });
+
+  describe('Generic template', () => {
+    let generic;
+
+    beforeEach(() => {
+      generic = new formatFbMessage.generic();
+    });
+
+    it('should be a class', () => {
+      expect(typeof formatFbMessage.generic).toBe('function');
+      expect(generic instanceof formatFbMessage.generic).toBeTruthy();
+    });
+
+    it('should throw an error if at least one bubble/element is not added', () => {
+      expect(() => generic.get()).toThrowError('Add at least one bubble first!');
+    });
+
+    it('should throw an error if bubble title does not exist', () => {
+      expect(() => generic.addBubble()).toThrowError('Bubble title cannot be empty');
+    });
+
+    it('should throw an error if bubble title is too long', () => {
+      expect(() => generic.addBubble('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua')).toThrowError('Bubble title cannot be longer than 80 characters');
+    });
+
+    it('should throw an error if bubble subtitle is too long', () => {
+      expect(() => generic.addBubble('Test', 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua')).toThrowError('Bubble subtitle cannot be longer than 80 characters');
+    });
+
+    it('should throw an error if there\'s more than 10 bubbles', () => {
+      expect(() =>
+        generic
+          .addBubble('1', 'hello')
+          .addBubble('2', 'hello')
+          .addBubble('3', 'hello')
+          .addBubble('4', 'hello')
+          .addBubble('5', 'hello')
+          .addBubble('6', 'hello')
+          .addBubble('7', 'hello')
+          .addBubble('8', 'hello')
+          .addBubble('9', 'hello')
+          .addBubble('10', 'hello')
+          .addBubble('11', 'hello')
+      )
+      .toThrowError('10 bubbles are maximum for Generic template');
+    });
+  });
+
+  xdescribe('Button template', () => {
+
+  });
+
+  xdescribe('Receipt template', () => {
+
+  });
+
+  xdescribe('Image attachment', () => {
+
+  });
+});

--- a/spec/facebook/facebook-format-message-spec.js
+++ b/spec/facebook/facebook-format-message-spec.js
@@ -123,7 +123,7 @@ describe('Facebook format message', () => {
       expect(generic.bubbles[0].buttons[0].url).not.toBeDefined();
     });
 
-    it('should add a button with title and payload if you pass valid format', () => {
+    it('should add a button with title and url if you pass valid format', () => {
       generic
         .addBubble('Test')
         .addButton('Title 1', 'http://google.com');
@@ -201,8 +201,98 @@ describe('Facebook format message', () => {
     });
   });
 
-  xdescribe('Button template', () => {
+  describe('Button template', () => {
+    it('should be a class', () => {
+      let button = new formatFbMessage.button('Test');
 
+      expect(typeof formatFbMessage.button).toBe('function');
+      expect(button instanceof formatFbMessage.button).toBeTruthy();
+    });
+
+    it('should throw an error if button text is not provided', () => {
+      expect(() => new formatFbMessage.button()).toThrowError('Button template text cannot be empty');
+    });
+
+    it('should throw an error if button text is longer than 80 characters', () => {
+      expect(() => new formatFbMessage.button('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua')).toThrowError('Button template text cannot be longer than 80 characters');
+    });
+
+    it('should create a button template with the text when valid text is provided', () => {
+      let button = new formatFbMessage.button('Test');
+
+      expect(button.text).toBe('Test');
+    });
+
+    it('should throw an error if you add a button without the title', () => {
+      let button = new formatFbMessage.button('Test');
+
+      expect(() => button.addButton()).toThrowError('Button title cannot be empty');
+    });
+
+    it('should throw an error if you add a button without the value', () => {
+      let button = new formatFbMessage.button('Test');
+
+      expect(() => button.addButton('Title')).toThrowError('Bubble value is required');
+    });
+
+    it('should add a button with title and payload if you pass valid format', () => {
+      let button = new formatFbMessage.button('Test');
+      button.addButton('Title 1', 1);
+
+      expect(button.buttons.length).toBe(1);
+      expect(button.buttons[0].title).toBe('Title 1');
+      expect(button.buttons[0].type).toBe('postback');
+      expect(button.buttons[0].payload).toBe(1);
+      expect(button.buttons[0].url).not.toBeDefined();
+    });
+
+    it('should add a button with title and url if you pass valid format', () => {
+      let button = new formatFbMessage.button('Test');
+      button.addButton('Title 1', 'http://google.com');
+
+      expect(button.buttons.length).toBe(1);
+      expect(button.buttons[0].title).toBe('Title 1');
+      expect(button.buttons[0].type).toBe('web_url');
+      expect(button.buttons[0].url).toBe('http://google.com');
+      expect(button.buttons[0].payload).not.toBeDefined();
+    });
+
+    it('should add 3 buttons with valid titles and formats', () => {
+      let button = new formatFbMessage.button('Test');
+      button
+        .addButton('b1', 'v1')
+        .addButton('b2', 'v2')
+        .addButton('b3', 'v3');
+
+      expect(button.buttons.length).toBe(3);
+      expect(button.buttons[0].title).toBe('b1');
+      expect(button.buttons[0].payload).toBe('v1');
+      expect(button.buttons[1].title).toBe('b2');
+      expect(button.buttons[1].payload).toBe('v2');
+      expect(button.buttons[2].title).toBe('b3');
+      expect(button.buttons[2].payload).toBe('v3');
+    });
+
+    it('should return a formated object in the end', () => {
+      expect(
+        new formatFbMessage.button('Test')
+          .addButton('Title 1', 1)
+          .get()
+      ).toEqual({
+        attachment: {
+          type: 'template',
+          payload: {
+            template_type: 'button',
+            text: 'Test',
+            buttons: [{
+              type: 'postback',
+              title: 'Title 1',
+              payload: 1
+            }]
+          }
+        }
+      });
+    });
   });
 
   xdescribe('Receipt template', () => {

--- a/spec/facebook/facebook-format-message-spec.js
+++ b/spec/facebook/facebook-format-message-spec.js
@@ -299,7 +299,37 @@ describe('Facebook format message', () => {
 
   });
 
-  xdescribe('Image attachment', () => {
+  describe('Image attachment', () => {
+    it('should be a class', () => {
+      let image = new formatFbMessage.image('http://google.com');
 
+      expect(typeof formatFbMessage.image).toBe('function');
+      expect(image instanceof formatFbMessage.image).toBeTruthy();
+    });
+
+    it('should throw an error if you add an image without the url', () => {
+      expect(() => new formatFbMessage.image()).toThrowError('Image template requires a valid URL as a first paramether');
+    });
+
+    it('should throw an error if you add an image with invalid url', () => {
+      expect(() => new formatFbMessage.image('google')).toThrowError('Image template requires a valid URL as a first paramether');
+    });
+
+    it('should add an image with given URL if URL is valid', () => {
+      let image = new formatFbMessage.image('http://google.com/path/to/image.png');
+
+      expect(image.url).toBe('http://google.com/path/to/image.png');
+    });
+
+    it('should return a formated object in the end', () => {
+      expect(
+        new formatFbMessage.image('http://google.com/path/to/image.png').get()
+      ).toEqual({
+        attachment: {
+          type: 'image',
+          url: 'http://google.com/path/to/image.png'
+        }
+      });
+    });
   });
 });

--- a/spec/facebook/facebook-format-message-spec.js
+++ b/spec/facebook/facebook-format-message-spec.js
@@ -1,4 +1,4 @@
-/*global describe, xdescribe, it, expect, beforeEach, require */
+/*global describe, it, expect, beforeEach, require */
 'use strict';
 
 const formatFbMessage = require('../../lib/facebook/format-message');
@@ -52,15 +52,13 @@ describe('Facebook format message', () => {
     });
 
     it('should throw an error if you try to add an url but not provide it', () => {
-      generic
-        .addBubble('Test');
+      generic.addBubble('Test');
 
       expect(() => generic.addUrl()).toThrowError('URL is required for addUrl method');
     });
 
     it('should throw an error if you try to add an url in invalid format', () => {
-      generic
-        .addBubble('Test');
+      generic.addBubble('Test');
 
       expect(() => generic.addUrl('http//invalid-url')).toThrowError('URL needs to be valid for addUrl method');
     });
@@ -88,13 +86,13 @@ describe('Facebook format message', () => {
       expect(() => generic.addImage('http//invalid-url')).toThrowError('Image URL needs to be valid for addImage method');
     });
 
-    it('should add an url if it is valid', () => {
+    it('should add an image if it is valid', () => {
       generic
         .addBubble('Test')
-        .addUrl('http://google.com/path/to/image.png');
+        .addImage('http://google.com/path/to/image.png');
 
       expect(generic.bubbles.length).toBe(1);
-      expect(generic.bubbles[0].item_url).toBe('http://google.com/path/to/image.png');
+      expect(generic.bubbles[0].image_url).toBe('http://google.com/path/to/image.png');
     });
 
     it('should throw an error if you add a button without the title', () => {
@@ -295,7 +293,254 @@ describe('Facebook format message', () => {
     });
   });
 
-  xdescribe('Receipt template', () => {
+  describe('Receipt template', () => {
+    it('should be a class', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+
+      expect(typeof formatFbMessage.receipt).toBe('function');
+      expect(receipt instanceof formatFbMessage.receipt).toBeTruthy();
+    });
+
+    it('should throw an error if recipient\'s name is not defined', () => {
+      expect(() => new formatFbMessage.receipt()).toThrowError('Recipient\'s name cannot be empty');
+    });
+
+    it('should throw an error if order number is not defined', () => {
+      expect(() => new formatFbMessage.receipt('John Doe')).toThrowError('Order number cannot be empty');
+    });
+
+    it('should throw an error if currency is not defined', () => {
+      expect(() => new formatFbMessage.receipt('John Doe', 'O123')).toThrowError('Currency cannot be empty');
+    });
+
+    it('should throw an error if payment method is not defined', () => {
+      expect(() => new formatFbMessage.receipt('John Doe', 'O123', '$')).toThrowError('Payment method cannot be empty');
+    });
+
+    it('should create a receipt template object if recipient, order number, currency and payment method are passed', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+
+      expect(typeof receipt).toBe('object');
+      expect(receipt.output.recipient_name).toBe('John Doe');
+      expect(receipt.output.order_number).toBe('O123');
+      expect(receipt.output.currency).toBe('$');
+      expect(receipt.output.payment_method).toBe('Paypal');
+    });
+
+    it('should throw an error if user tries to add timestamp but don\'t provide it', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+
+      expect(() => receipt.addTimestamp()).toThrowError('Timestamp is required for addTimestamp method');
+    });
+
+    it('should throw an error if timestamp is not valid date object', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+
+      expect(() => receipt.addTimestamp('invalid-timestamp')).toThrowError('Timestamp needs to be a valid Date object');
+    });
+
+    it('should add a timestamp if it is a valid date object', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addTimestamp(new Date('2016-06-14T20:55:31.438Z'));
+
+      expect(receipt.output.timestamp).toBe(new Date('2016-06-14T20:55:31.438Z').getTime());
+    });
+
+    it('should should throw an error if user tries to add order url but doesn\'t provide it', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+
+      expect(() => receipt.addOrderUrl()).toThrowError('Url is required for addOrderUrl method');
+    });
+
+    it('should should throw an error if order url is not a valid url', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+
+      expect(() => receipt.addOrderUrl('http//invalid-url')).toThrowError('Url needs to be valid for addOrderUrl method');
+    });
+
+    it('should add an order url if it is a valid url', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addOrderUrl('http://google.com');
+
+      expect(receipt.output.order_url).toBe('http://google.com');
+    });
+
+    it('should throw an error if there\'s no items in order', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+
+      expect(() => receipt.get()).toThrowError('At least one element/item is required');
+    });
+
+    it('should throw an error if user tries to add an item without title', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+
+      expect(() => receipt.addItem()).toThrowError('Item title is required');
+    });
+
+    it('should add an item if valid title is provided', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addItem('Title');
+
+      expect(receipt.output.elements.length).toBe(1);
+      expect(receipt.output.elements[0].title).toBe('Title');
+    });
+
+    it('should throw an error if user tries to add an item\'s subtitle but doesn\'t provide it', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addItem('Title');
+
+      expect(() => receipt.addSubtitle()).toThrowError('Subtitle is required for addSubtitle method');
+    });
+
+    it('should add an item with a subtitle if valid subtitle is provided', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title')
+        .addSubtitle('Subtitle');
+
+      expect(receipt.output.elements.length).toBe(1);
+      expect(receipt.output.elements[0].subtitle).toBe('Subtitle');
+    });
+
+    it('should throw an error if user tries to add an item\'s quantity but doesn\'t provide it', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addItem('Title');
+
+      expect(() => receipt.addQuantity()).toThrowError('Quantity is required for addQuantity method');
+    });
+
+    it('should throw an error if user tries to add an item\'s quantity which is not a number', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addItem('Title');
+
+      expect(() => receipt.addQuantity('test')).toThrowError('Quantity needs to be a number');
+    });
+
+    it('should add an item with a quantity if valid number is provided', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title')
+        .addQuantity(42);
+
+      expect(receipt.output.elements.length).toBe(1);
+      expect(receipt.output.elements[0].quantity).toBe(42);
+    });
+
+    it('should throw an error if user tries to add an item\'s price but doesn\'t provide it', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addItem('Title');
+
+      expect(() => receipt.addPrice()).toThrowError('Price is required for addPrice method');
+    });
+
+    it('should throw an error if user tries to add an item\'s price which is not a number', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addItem('Title');
+
+      expect(() => receipt.addPrice('test')).toThrowError('Price needs to be a number');
+    });
+
+    it('should add an item with a quantity if valid price is provided', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title')
+        .addPrice(4.2);
+
+      expect(receipt.output.elements.length).toBe(1);
+      expect(receipt.output.elements[0].price).toBe(4.2);
+    });
+
+    it('should throw an error if user tries to add an item\'s currency but doesn\'t provide it', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addItem('Title');
+
+      expect(() => receipt.addCurrency()).toThrowError('Currency is required for addCurrency method');
+    });
+
+    it('should add an item with a currency if valid currency is provided', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title')
+        .addCurrency('$');
+
+      expect(receipt.output.elements.length).toBe(1);
+      expect(receipt.output.elements[0].currency).toBe('$');
+    });
+
+    it('should throw an error if user tries to add an item\'s image but doesn\'t provide it', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addItem('Title');
+
+      expect(() => receipt.addImage()).toThrowError('Url is required for addImage method');
+    });
+
+    it('should throw an error if user tries to add an item\'s image which is not a valid url', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt.addItem('Title');
+
+      expect(() => receipt.addImage('test')).toThrowError('Valid url is required for addImage method');
+    });
+
+    it('should add an item with an image if valid url is provided', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title')
+        .addImage('http://google.com/path/to/image.png');
+
+      expect(receipt.output.elements.length).toBe(1);
+      expect(receipt.output.elements[0].image_url).toBe('http://google.com/path/to/image.png');
+    });
+
+    it('should add more than 1 item if titles are valid', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title 1')
+        .addItem('Title 2');
+
+      expect(receipt.output.elements.length).toBe(2);
+      expect(receipt.output.elements[0].title).toBe('Title 1');
+      expect(receipt.output.elements[1].title).toBe('Title 2');
+    });
+
+    it('should throw an error if user tries to add a shipping address without a street address', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title 1');
+
+      expect(() => receipt.addShippingAddress()).toThrowError('Street is required for addShippingAddress');
+    });
+
+    it('should throw an error if user tries to add a shipping address without the city', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title 1');
+
+      expect(() => receipt.addShippingAddress('Bulevar Nikole Tesle 42', null)).toThrowError('City is required for addShippingAddress method');
+    });
+
+    it('should throw an error if user tries to add a shipping address without a postal code', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title 1');
+
+      expect(() => receipt.addShippingAddress('Bulevar Nikole Tesle 42', null, 'Belgrade')).toThrowError('Zip code is required for addShippingAddress method');
+    });
+
+    it('should throw an error if user tries to add a shipping address without the state', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title 1');
+
+      expect(() => receipt.addShippingAddress('Bulevar Nikole Tesle 42', null, 'Belgrade', 11070)).toThrowError('State is required for addShippingAddress method');
+    });
+
+    it('should throw an error if user tries to add a shipping address without the country', () => {
+      let receipt = new formatFbMessage.receipt('John Doe', 'O123', '$', 'Paypal');
+      receipt
+        .addItem('Title 1');
+
+      expect(() => receipt.addShippingAddress('Bulevar Nikole Tesle 42', null, 'Belgrade', 11070, 'Serbia')).toThrowError('Country is required for addShippingAddress method');
+    });
 
   });
 


### PR DESCRIPTION
Adds generator for FB templates.

Options:
```js
new fbTemplate.generic() // Generic template
new fbTemplate.buttons() // Buttons template
new fbTemplate.receipt() // Receipt template
new fbTemplate.image()   // Image attachment
```

Usage:

```js
const fbTemplate = require('claudia-bot-builder').fbTemplate

let message = new fbTemplate.generic()
  .addBubble('1', 'hello')
    .addUrl('http://google.com')
  .addBubble('2', 'hello')
    .addImage('http://path.to/some/image.png')
  .addBubble('3', 'hello')
    .addButton('Button 1', 'postback value')
    .addButton('Button 2', 'http://google.com')
  .get();

console.log(JSON.stringify(message));
/*
Output:

{  
  "attachment":{  
    "type":"template",
    "payload":{  
      "template_type":"generic",
      "elements":[  
        {  
          "title":"1",
          "subtitle":"hello",
          "item_url":"http://google.com"
        },
        {  
          "title":"2",
          "subtitle":"hello",
          "image_url":"http://path.to/some/image.png"
        },
        {  
          "title":"3",
          "subtitle":"hello",
          "buttons":[  
            {  
              "title":"Button 1",
              "type":"postback",
              "payload":"postback value"
            },
            {  
              "title":"Button 2",
              "type":"web_url",
              "url":"http://google.com"
            }
          ]
        }
      ]
    }
  }
}
*/
```