### PR TITLE
support longer top level domain names

### DIFF
--- a/lib/is-url.js
+++ b/lib/is-url.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = function isUrl(url) {
-  const pattern = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
+  const pattern = /[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,63}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?/gi;
   return pattern.test(url);
 };


### PR DESCRIPTION
DNS allows for a maximum of 63 characters for an individual label.

Source:
http://stackoverflow.com/questions/9238640/how-long-can-a-tld-possibly-be
http://en.wikipedia.org/wiki/Domain_Name_System#cite_ref-rfc1034_1-2