### PR TITLE
adding additional slack tokens for outgoing webhooks and slack apps

### DIFF
--- a/lib/slack/setup.js
+++ b/lib/slack/setup.js
@@ -15,22 +15,25 @@ module.exports = function slackSetup(api, bot, logError, optionalParser, optiona
   api.get('/slack/slash-command', () => 'OK');
 
   api.post('/slack/slash-command', request => {
-    if (request.post.token === request.env.slackToken)
+    if ((request.post.command &&
+          (request.post.token === request.env.slackToken || request.post.token === request.env.slackVerificationToken))
+        ||
+        (request.post.trigger_word && request.post.token === request.env.slackWebhookToken))
       return bot(parser(request.post), request)
         .then(responder)
         .catch(logError);
     else
-      return responder('unmatched token' + ' ' + request.post.token + ' ' + request.env.slackToken);
+      return responder('unmatched token' + ' ' + request.post.token + ' ' + request.env.slackToken + ' ' + request.env.slackWebhookToken + ' ' + request.env.slackVerificationToken);
   });
 
   api.post('/slack/message-action', request => {
     const payload = JSON.parse(request.post.payload);
-    if (payload.token === request.env.slackToken)
+    if (payload.token === request.env.slackVerificationToken || payload.token === request.env.slackToken)
       return bot(parser(payload), request)
         .then(responder)
         .catch(logError);
     else
-      return responder('unmatched token' + ' ' + payload.token + ' ' + request.env.slackToken);
+      return responder('unmatched token' + ' ' + payload.token + ' ' + request.env.slackToken + ' ' + request.env.slackVerificationToken);
   });
 
   api.get('/slack/landing', request => {
@@ -55,16 +58,18 @@ module.exports = function slackSetup(api, bot, logError, optionalParser, optiona
       if (options['configure-slack-slash-command']) {
         console.log(`\n\n${color.green}Slack slash command setup${color.reset}\n`);
         console.log(`\nFollowing info is required for the setup, for more info check the documentation.\n`);
+        console.log(`\nNote that you can add one token for a slash command, and a second token for an outgoing webhook.\n`);
         console.log(`\nYour Slack slash command Request URL (POST only) is ${color.cyan}${lambdaDetails.apiUrl}/slack/slash-command${color.reset}\n`);
         console.log(`${color.dim}If you are building full-scale Slack app instead of just a slash command for your team, restart with --configure-slack-slash-app${color.reset} \n`);
 
-        return prompt(['Slack token'])
+        return prompt(['Slack token', 'Outgoing webhook token'])
           .then(results => {
             const deployment = {
               restApiId: lambdaDetails.apiId,
               stageName: lambdaDetails.alias,
               variables: {
-                slackToken: results['Slack token']
+                slackToken: results['Slack token'],
+                slackWebhookToken: results['Outgoing webhook token']
               }
             };
 
@@ -82,7 +87,7 @@ module.exports = function slackSetup(api, bot, logError, optionalParser, optiona
         console.log(`\nIf you are using buttons, your Action URL is ${color.cyan}${lambdaDetails.apiUrl}/slack/message-action${color.reset}\n`);
         console.log(`${color.dim}If you are building just a slash command integration for your team and you don't need full-scale Slack app restart with --configure-slack-slash-command${color.reset} \n`);
 
-        return prompt(['Slack Client ID', 'Slack Client Secret', 'Slack token', 'Home page URL'])
+        return prompt(['Slack Client ID', 'Slack Client Secret', 'Slack verification token', 'Home page URL'])
           .then(results => {
             const deployment = {
               restApiId: lambdaDetails.apiId,
@@ -90,7 +95,7 @@ module.exports = function slackSetup(api, bot, logError, optionalParser, optiona
               variables: {
                 slackClientId: results['Slack Client ID'],
                 slackClientSecret: results['Slack Client Secret'],
-                slackToken: results['Slack token'],
+                slackVerificationToken: results['Slack verification token'],
                 slackHomePageUrl: results['Home page URL'],
                 slackRedirectUrl: `${lambdaDetails.apiUrl}/slack/landing`
               }


### PR DESCRIPTION
Hi,

by default, Claudia recognises a single Slack token. However, the same API endpoint works with a Slack slash command, an outgoing webhook, and a Slack app. Unfortunately these different integrations create separate tokens, so there can be one token for slash commands, another for outgoing webhooks, and a third for an app. And - as far as I know -  there is no way in Slack to set the token for a configuration, thus all 3 tokens can not be made identical on Slack side.

To solve this, I added 2 additional Slack tokens to the setup for outgoing webhooks and apps, which are checked on invocation. For backward compatibility, the original slackToken will still work for any configuration.

Additional tests were created, and all pass.

Thanks for the awesome work, which is a great help with Lambda, APIs, and bots, and best regards, Holger