### PR TITLE
Prevent leak of slack secrets

### DIFF
--- a/lib/slack/setup.js
+++ b/lib/slack/setup.js
@@ -23,7 +23,7 @@ module.exports = function slackSetup(api, bot, logError, optionalParser, optiona
         .then(responder)
         .catch(logError);
     else
-      return responder('unmatched token' + ' ' + request.post.token + ' ' + request.env.slackToken + ' ' + request.env.slackWebhookToken + ' ' + request.env.slackVerificationToken);
+      return responder('unmatched token' + ' ' + request.post.token);
   });
 
   api.post('/slack/message-action', request => {
@@ -33,7 +33,7 @@ module.exports = function slackSetup(api, bot, logError, optionalParser, optiona
         .then(responder)
         .catch(logError);
     else
-      return responder('unmatched token' + ' ' + payload.token + ' ' + request.env.slackToken + ' ' + request.env.slackVerificationToken);
+      return responder('unmatched token' + ' ' + payload.token);
   });
 
   api.get('/slack/landing', request => {

--- a/spec/slack/slack-setup-spec.js
+++ b/spec/slack/slack-setup-spec.js
@@ -89,7 +89,7 @@ describe('Slack setup', () => {
       });
 
       expect(responder.calls.count()).toEqual(1);
-      expect(responder).toHaveBeenCalledWith('unmatched token slack-token slack-invalid-token slack-webhook-token slack-invalid-verification-token');
+      expect(responder).toHaveBeenCalledWith('unmatched token slack-token');
     });
 
     it('replies with Error when webhook tokens do not match for a webhook message', () => {
@@ -104,7 +104,7 @@ describe('Slack setup', () => {
       });
 
       expect(responder.calls.count()).toEqual(1);
-      expect(responder).toHaveBeenCalledWith('unmatched token slack-webhook-token slack-token slack-invalid-webhook-token slack-verification-token');
+      expect(responder).toHaveBeenCalledWith('unmatched token slack-webhook-token');
     });
 
     it('invokes parser if the slash command request is valid with the slack token', () => {
@@ -265,7 +265,7 @@ describe('Slack setup', () => {
       });
 
       expect(responder.calls.count()).toEqual(1);
-      expect(responder).toHaveBeenCalledWith('unmatched token slack-verification-token slack-invalid-token slack-invalid-verification-token');
+      expect(responder).toHaveBeenCalledWith('unmatched token slack-verification-token');
     });
 
     it('invokes parser if the request contains a valid verification token', () => {


### PR DESCRIPTION
Remove request.env.slackToken, request.env.slackWebhookToken and request.env.slackVerificationToken from invalid request response body.
This prevents leaking secrets, since before the fix they were displayed to any request that does not come with the right slack token.