### PR TITLE
Fb messenger example fix

### DIFF
--- a/docs/FB_TEMPLATE_MESSAGE_BUILDER.md
+++ b/docs/FB_TEMPLATE_MESSAGE_BUILDER.md
@@ -69,9 +69,9 @@ const fbTemplate = botBuilder.fbTemplate;
 
 module.exports = botBuilder(message => {
   if (message.type === 'facebook') {
-    const message = new fbTemplate.Text('What\'s your favorite House in Game Of Thrones');
+    const newMessage = new fbTemplate.Text('What\'s your favorite House in Game Of Thrones');
 
-    return message
+    return newMessage
       .addQuickReply('Stark', 'STARK')
       .addQuickReply('Lannister', 'LANNISTER')
       .addQuickReply('Targaryen', 'TARGARYEN')


### PR DESCRIPTION
Updated message variable name to newMessage. Existing example code had the same variable name and because of that the example did not work. 