### PR TITLE
Allows manual override of FB button type to allow buttons such as Call button

### DIFF
--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -244,7 +244,7 @@ class Generic extends FacebookTemplate {
       button.payload = value;
     }
 
-    if (!type) {
+    if (type) {
       button.type = type;
     }
 

--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -218,7 +218,7 @@ class Generic extends FacebookTemplate {
     return this;
   }
 
-  addButton(title, value) {
+  addButton(title, value, type) {
     const bubble = this.getLastBubble();
 
     bubble.buttons = bubble.buttons || [];
@@ -242,6 +242,10 @@ class Generic extends FacebookTemplate {
     } else {
       button.type = 'postback';
       button.payload = value;
+    }
+
+    if (!type) {
+      button.type = type;
     }
 
     bubble.buttons.push(button);

--- a/spec/facebook/facebook-format-message-spec.js
+++ b/spec/facebook/facebook-format-message-spec.js
@@ -245,6 +245,14 @@ describe('Facebook format message', () => {
       expect(generic.bubbles[0].buttons[2].payload).toBe('v3');
     });
 
+    it('should override type when a type parameter is passed', () => {
+      generic
+        .addBubble('Test')
+        .addButton('b1', '+123456789', 'phone_number');
+
+      expect(generic.bubbles[0].buttons[0].type).toBe('phone_number');
+    });
+
     it('should throw an error if you add more than 3 buttons', () => {
       generic
         .addBubble('Test');


### PR DESCRIPTION
https://developers.facebook.com/docs/messenger-platform/send-api-reference/call-button