### PR TITLE
fix: character length on facebook button template

### DIFF
--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -287,7 +287,7 @@ class Generic extends FacebookTemplate {
     };
 
     bubble.buttons.push(button);
-  
+
     return this;
   }
 
@@ -308,8 +308,8 @@ class Button extends FacebookTemplate {
     if (!text)
       throw new Error('Button template text cannot be empty');
 
-    if (text.length > 80)
-      throw new Error('Button template text cannot be longer than 80 characters');
+    if (text.length > 320)
+      throw new Error('Button template text cannot be longer than 320 characters');
 
     this.template = {
       attachment: {
@@ -349,7 +349,7 @@ class Button extends FacebookTemplate {
 
     return this;
   }
-  
+
   get() {
     if (this.template.attachment.payload.buttons.length === 0)
       throw new Error('Add at least one button first!');

--- a/spec/facebook/facebook-format-message-spec.js
+++ b/spec/facebook/facebook-format-message-spec.js
@@ -351,8 +351,8 @@ describe('Facebook format message', () => {
       expect(() => new formatFbMessage.Button()).toThrowError('Button template text cannot be empty');
     });
 
-    it('should throw an error if button text is longer than 80 characters', () => {
-      expect(() => new formatFbMessage.Button('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua')).toThrowError('Button template text cannot be longer than 80 characters');
+    it('should throw an error if button text is longer than 320 characters', () => {
+      expect(() => new formatFbMessage.Button(Array(321).fill('x').join(''))).toThrowError('Button template text cannot be longer than 320 characters');
     });
 
     it('should create a button template with the text when valid text is provided', () => {


### PR DESCRIPTION
This changes the character limit on the Facebook Button template to the value defined in the [Facebook docs](https://developers.facebook.com/docs/messenger-platform/send-api-reference/button-template)

> text must be UTF-8 and has a 320 character limit

resolves #60 