### PR TITLE
Modified condition to parse Quick Reply properly

### DIFF
--- a/lib/facebook/parse.js
+++ b/lib/facebook/parse.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(messageObject) {
-  if (messageObject && messageObject.sender && messageObject.sender.id && messageObject.message && messageObject.message.text) {
+  if (messageObject && messageObject.sender && messageObject.sender.id && messageObject.message && messageObject.message.text && !messageObject.message.quick_reply) {
     return {
       sender: messageObject.sender.id,
       text: messageObject.message.text,


### PR DESCRIPTION
This little modification solves the issue of quick reply not being able to parse out as postback.
Even if the request contains quick reply, Claudia won't be able to parse it as a postback because the first condition is already fulfilled and it never goes till 'else-if' statement where the quick-reply is actually parsed.