### PR TITLE
Support commas in URLs

### DIFF
--- a/lib/is-url.js
+++ b/lib/is-url.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = function isUrl(url) {
-  const pattern = /^[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,63}\b(\/[-a-zA-Z0-9@:%_\+.~#?&//=]*)?$/gi;
+  const pattern = /^[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,63}\b(\/[-a-zA-Z0-9@:%_\+.,~#?&//=]*)?$/gi;
   return pattern.test(url);
 };

--- a/lib/is-url.js
+++ b/lib/is-url.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = function isUrl(url) {
-  const pattern = /^[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,63}\b(\/[-a-zA-Z0-9@:%_\+.,~#?&//=]*)?$/gi;
+  const pattern = /^[-a-zA-Z0-9@:%_\+.~#?&//=]{2,256}\.[a-z]{2,63}\b(\/[-a-zA-Z0-9@:%_\(\)\+.,~#?&//=]*)?$/gi;
   return pattern.test(url);
 };

--- a/spec/is-url-spec.js
+++ b/spec/is-url-spec.js
@@ -16,6 +16,7 @@ describe('isUrl', () => {
     expect(isUrl('https://www.claudiajs.com')).toBeTruthy();
     expect(isUrl('https://github.com/claudiajs')).toBeTruthy();
     expect(isUrl('https://github.com/claudiajs/claudia-bot-builder')).toBeTruthy();
+    expect(isUrl('https://www.google.com/#q=claudia,bot')).toBeTruthy();
   });
   it('should return false if url is in the sentence', () => {
     expect(isUrl('This is a valid url: http://google.com')).toBeFalsy();


### PR DESCRIPTION
Currently Claudia will throw an error when commas are put into URLs, but they're allowed characters on some websites (e.g. https://share.here.com/r/52.39952,13.04787,Potsdam/52.51607,13.37699,Berlin)