### PR TITLE
Add setnotificationtype to facebooktemplate

### DIFF
--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -12,6 +12,13 @@ class FacebookTemplate {
     this.template = {};
   }
 
+  setNotificationType(type) {
+    if (type !== 'REGULAR' && type !== 'SILENT_PUSH' && type !== 'NO_PUSH')
+      throw new Error('Notification type must be one of REGULAR, SILENT_PUSH, or NO_PUSH');
+    this.template.notification_type = type;
+    return this;
+  }
+
   addQuickReply(text, payload, imageUrl) {
     if (!text || !payload)
       throw new Error('Both text and payload are required for a quick reply');

--- a/lib/facebook/reply.js
+++ b/lib/facebook/reply.js
@@ -13,6 +13,9 @@ module.exports = function fbReply(recipient, message, fbAccessToken) {
           id: recipient
         }
       };
+      if (message.hasOwnProperty('notification_type')) {
+        messageBody.notification_type = message.notification_type;
+      }
       if (message.hasOwnProperty('sender_action')) {
         messageBody.sender_action = message.sender_action;
       } else {

--- a/spec/facebook/facebook-format-message-spec.js
+++ b/spec/facebook/facebook-format-message-spec.js
@@ -109,6 +109,25 @@ describe('Facebook format message', () => {
       expect(() => message.addQuickReply('title', 'PAYLOAD')).toThrowError('There can not be more than 11 quick replies');
     });
 
+    it('should set the notification type', () => {
+      const regular = new formatFbMessage.Text('Some text')
+        .setNotificationType('REGULAR')
+        .get();
+      expect(regular.notification_type).toBe('REGULAR');
+      const silent = new formatFbMessage.Text('Some text')
+        .setNotificationType('SILENT_PUSH')
+        .get();
+      expect(silent.notification_type).toBe('SILENT_PUSH');
+      const none = new formatFbMessage.Text('Some text')
+        .setNotificationType('NO_PUSH')
+        .get();
+      expect(none.notification_type).toBe('NO_PUSH');
+    });
+
+    it('should throw an on setNotificationType with invalid value', () => {
+      expect(() => new formatFbMessage.Text('Some text').setNotificationType('FACE_SLAP')).toThrowError('Notification type must be one of REGULAR, SILENT_PUSH, or NO_PUSH');
+    });
+
     it('should trim the title if it is too long', () => {
       let title = new Array(4).join('0123456789');
       const message = new formatFbMessage.Text('Some text')


### PR DESCRIPTION
Support for Facebook's notification type: https://developers.facebook.com/docs/messenger-platform/send-api-reference