### PR TITLE
Handle incoming MMS from Twilio

### DIFF
--- a/lib/twilio/parse.js
+++ b/lib/twilio/parse.js
@@ -1,16 +1,36 @@
 'use strict';
 const qs = require('querystring');
 
+// Get URLs to attached media in MMS.
+function createMediaArray(messageObject) {
+  return Object.keys(messageObject)
+    .filter(function (key) {
+      return key.match(/^MediaUrl/);
+    })
+    .map(function (key) {
+      return messageObject[key];
+    });
+}
+
 module.exports = function(messageObject) {
   messageObject = qs.parse(messageObject);
   console.log('TWILIO PARSE RECEIVED MESSAGE:', messageObject);
-  if (messageObject && typeof messageObject.Body !== 'undefined' && messageObject.Body.length > 0 &&
-    typeof messageObject.From !== 'undefined' && messageObject.From.length > 0){
-    return {
+  if (!messageObject) return;
+  var hasBody = typeof messageObject.Body !== 'undefined'
+    && messageObject.Body.length > 0;
+  var hasSender = typeof messageObject.From !== 'undefined'
+    && messageObject.From.length > 0;
+  var hasMedia = parseInt(messageObject.numMedia || 0);
+  if (hasBody && hasSender) {
+    var o = {
       sender: messageObject.From,
       text: messageObject.Body,
       originalRequest: messageObject,
       type: 'twilio'
     };
+    if (hasMedia) {
+      o.media = createMediaArray(messageObject);
+    }
+    return o;
   }
 };

--- a/lib/twilio/parse.js
+++ b/lib/twilio/parse.js
@@ -2,8 +2,8 @@
 const qs = require('querystring');
 
 module.exports = function(messageObject) {
-  console.log('TWILIO PARSE RECEIVED MESSAGE:', messageObject);
   messageObject = qs.parse(messageObject);
+  console.log('TWILIO PARSE RECEIVED MESSAGE:', messageObject);
   if (messageObject && typeof messageObject.Body !== 'undefined' && messageObject.Body.length > 0 &&
     typeof messageObject.From !== 'undefined' && messageObject.From.length > 0){
     return {

--- a/lib/twilio/parse.js
+++ b/lib/twilio/parse.js
@@ -2,7 +2,7 @@
 const qs = require('querystring');
 
 module.exports = function(messageObject) {
-
+  console.log('TWILIO PARSE RECEIVED MESSAGE:', messageObject);
   messageObject = qs.parse(messageObject);
   if (messageObject && typeof messageObject.Body !== 'undefined' && messageObject.Body.length > 0 &&
     typeof messageObject.From !== 'undefined' && messageObject.From.length > 0){

--- a/lib/twilio/parse.js
+++ b/lib/twilio/parse.js
@@ -3,26 +3,26 @@ const qs = require('querystring');
 
 // Get URLs to attached media in MMS.
 function createMediaArray(messageObject) {
-  return Object.keys(messageObject)
-    .filter(function (key) {
-      return key.match(/^MediaUrl/);
-    })
-    .map(function (key) {
-      return messageObject[key];
+  const media = [];
+  for (let i = 0; i < messageObject.NumMedia; i++) {
+    media.push({
+      contentType: messageObject[`MediaContentType${i}`],
+      url: messageObject[`MediaUrl${i}`]
     });
+  }
+  return media;
 }
 
 module.exports = function(messageObject) {
   messageObject = qs.parse(messageObject);
-  console.log('TWILIO PARSE RECEIVED MESSAGE:', messageObject);
   if (!messageObject) return;
-  var hasBody = typeof messageObject.Body !== 'undefined'
+  const hasBody = typeof messageObject.Body !== 'undefined'
     && messageObject.Body.length > 0;
-  var hasSender = typeof messageObject.From !== 'undefined'
+  const hasSender = typeof messageObject.From !== 'undefined'
     && messageObject.From.length > 0;
-  var hasMedia = parseInt(messageObject.NumMedia || 0);
+  const hasMedia = parseInt(messageObject.NumMedia || 0);
   if (hasSender && (hasBody || hasMedia)) {
-    var o = {
+    const o = {
       sender: messageObject.From,
       text: messageObject.Body,
       originalRequest: messageObject,

--- a/lib/twilio/parse.js
+++ b/lib/twilio/parse.js
@@ -20,8 +20,8 @@ module.exports = function(messageObject) {
     && messageObject.Body.length > 0;
   var hasSender = typeof messageObject.From !== 'undefined'
     && messageObject.From.length > 0;
-  var hasMedia = parseInt(messageObject.numMedia || 0);
-  if (hasBody && hasSender) {
+  var hasMedia = parseInt(messageObject.NumMedia || 0);
+  if (hasSender && (hasBody || hasMedia)) {
     var o = {
       sender: messageObject.From,
       text: messageObject.Body,

--- a/spec/twilio/twilio-parse-spec.js
+++ b/spec/twilio/twilio-parse-spec.js
@@ -16,6 +16,10 @@ describe('Twilio parse', () => {
     expect(parse(qs.stringify({From: '+3333333333'}))).toBeUndefined();
     expect(parse(qs.stringify({From: '+3333333333', Body: undefined}))).toBeUndefined();
   });
+  it('returns nothing if the Body is undefined or missing and there are 0 media attachments', () => {
+    expect(parse(qs.stringify({From: '+3333333333'}))).toBeUndefined();
+    expect(parse(qs.stringify({From: '+3333333333', Body: undefined, NumMedia: '0'}))).toBeUndefined();
+  });
   it('returns nothing if the From is undefined or missing', () => {
     expect(parse(qs.stringify({Body: 'SMS Twilio'}))).toBeUndefined();
     expect(parse(qs.stringify({From: undefined, Body: 'SMS Twilio'}))).toBeUndefined();

--- a/spec/twilio/twilio-parse-spec.js
+++ b/spec/twilio/twilio-parse-spec.js
@@ -24,4 +24,14 @@ describe('Twilio parse', () => {
     var msg = qs.stringify({From: '+3333333333', Body: 'SMS Twilio'});
     expect(parse(msg)).toEqual({ sender: '+3333333333', text: 'SMS Twilio', originalRequest: qs.parse(msg), type: 'twilio'});
   });
+  it('returns a parsed object when From is present and MMS attachments exist', () => {
+    var msg = qs.stringify({From: '+3333333333', NumMedia: '1', MediaContentType0: 'image/jpeg', MediaUrl0: 'https://api.twilio.com/test'});
+    expect(parse(msg)).toEqual({
+      sender: '+3333333333',
+      text: undefined,
+      originalRequest: qs.parse(msg),
+      type: 'twilio',
+      media: [{ contentType: 'image/jpeg', url: 'https://api.twilio.com/test' }]
+    });
+  });
 });

--- a/spec/twilio/twilio-parse-spec.js
+++ b/spec/twilio/twilio-parse-spec.js
@@ -17,7 +17,7 @@ describe('Twilio parse', () => {
     expect(parse(qs.stringify({From: '+3333333333', Body: undefined}))).toBeUndefined();
   });
   it('returns nothing if the Body is undefined or missing and there are 0 media attachments', () => {
-    expect(parse(qs.stringify({From: '+3333333333'}))).toBeUndefined();
+    expect(parse(qs.stringify({From: '+3333333333', NumMedia: '0'}))).toBeUndefined();
     expect(parse(qs.stringify({From: '+3333333333', Body: undefined, NumMedia: '0'}))).toBeUndefined();
   });
   it('returns nothing if the From is undefined or missing', () => {

--- a/spec/twilio/twilio-parse-spec.js
+++ b/spec/twilio/twilio-parse-spec.js
@@ -34,4 +34,30 @@ describe('Twilio parse', () => {
       media: [{ contentType: 'image/jpeg', url: 'https://api.twilio.com/test' }]
     });
   });
+  it('returns a parsed object where From is present and multiple MMS attachments exist', () => {
+    var msg = qs.stringify({
+      From: '+3333333333',
+      NumMedia: '2',
+      MediaContentType0: 'image/jpeg',
+      MediaContentType1: 'video/mp4',
+      MediaUrl0: 'https://api.twilio.com/test0',
+      MediaUrl1: 'https://api.twilio.com/test1'
+    });
+    expect(parse(msg)).toEqual({
+      sender: '+3333333333',
+      text: undefined,
+      originalRequest: qs.parse(msg),
+      type: 'twilio',
+      media: [
+        {
+          contentType: 'image/jpeg',
+          url: 'https://api.twilio.com/test0'
+        },
+        {
+          contentType: 'video/mp4',
+          url: 'https://api.twilio.com/test1'
+        }
+      ]
+    });
+  });
 });


### PR DESCRIPTION
This update adds a `media` key to the parsed object that contains an array of objects with `url` and `contentType` keys for each MMS media attachment.

It updates the conditional checks to support messages with no body text as long as media is present.

I tested it on a deployed bot by inspecting the CloudWatch logs.