### PR TITLE
catch messaging_referrals in fb/parse

### DIFF
--- a/lib/facebook/parse.js
+++ b/lib/facebook/parse.js
@@ -1,7 +1,17 @@
 'use strict';
 
 module.exports = function(messageObject) {
-  if (messageObject && messageObject.sender && messageObject.sender.id && messageObject.message && messageObject.message.text && !messageObject.message.quick_reply &&
+  if (messageObject && messageObject.sender && messageObject.sender.id && messageObject.referral && messageObject.referral.source && messageObject.referral.type) {
+    //  catch all referrals from messaging_referrals
+    return {
+      sender: messageObject.sender.id,
+      text: messageObject.referral.ref || 'discover_tab',
+      referral: true,
+      originalRequest: messageObject,
+      type: 'facebook'
+    };
+  }
+  else if (messageObject && messageObject.sender && messageObject.sender.id && messageObject.message && messageObject.message.text && !messageObject.message.quick_reply &&
     (typeof messageObject.delivery !== 'object' && typeof messageObject.read !== 'object' && (!messageObject.message || !messageObject.message.is_echo))) { // Disable delivery and read reports and message echos
     return {
       sender: messageObject.sender.id,


### PR DESCRIPTION
this branch is edited from tag v2.15 intended to catch fb/messaging_referrals.
- it catches all types of referrals, and put referral.ref in request.text when possible
- it adds a referral boolean
- it is placed ahead of other condition checks to not get hidden

Thank you very much for the wonderful and hackable project :)