### PR TITLE
Skype reply markdown/XML support

### DIFF
--- a/docs/SKYPE_CUSTOM_MESSAGES.md
+++ b/docs/SKYPE_CUSTOM_MESSAGES.md
@@ -34,7 +34,35 @@ Carousel class gives you ability to add Hero, Thumbnail and Receipt messages. Se
 
 ## Text messages
 
-If you simply want to answer with the text you can just return text.
+If you simply want to answer with the text you can just return text. And if you want your messages Markdown or XML support, use this API.
+
+### API
+
+`Text` (class) - Class that allows you to build a text messages.
+
+_Arguments:_
+
+- text, string (required) - message you want to send
+- format, string (optional) - `plain`, `markdown` or `xml`. default is `plain`.
+
+### Methods
+
+| Method                   | Required | Arguments                                | Returns                           | Description                              |
+| ------------------------ | -------- | ---------------------------------------- | --------------------------------- | ---------------------------------------- |
+| get                      | Yes      | No arguments                             | Formatted JSON to pass as a reply | Get method is required and it returns a formatted JSON that is ready to be passed as a response to Skype Messenger |
+
+### Example
+
+```javascript
+const botBuilder = require('claudia-bot-builder');
+const skypeTemplate = botBuilder.skypeTemplate;
+
+module.exports = botBuilder(message => {
+  if (message.type === 'skype')
+    return new skypeTemplate.Text('**HELLO**!', 'markdown').get();
+});
+```
+more markdown or XML syntax, refer to:  https://docs.microsoft.com/en-us/bot-framework/rest-api/bot-framework-rest-connector-create-messages
 
 
 

--- a/lib/skype/format-message.js
+++ b/lib/skype/format-message.js
@@ -11,6 +11,20 @@ class SkypeMessage {
   }
 }
 
+class Text extends SkypeMessage {
+  constructor(text, format) {
+    super();
+    if (!text || typeof text !== 'string')
+      throw new Error('Text is required for Skype Text template');
+
+    this.template = {
+      type: 'message',
+      text: text,
+      textFormat: format || 'plain'
+    };
+  }
+}
+
 class Photo extends SkypeMessage {
   constructor(base64Photo) {
     super();
@@ -18,8 +32,9 @@ class Photo extends SkypeMessage {
       throw new Error('Photo is required for the Skype Photo template');
 
     this.template = {
-      type: 'message/image',
+      type: 'message',
       attachments: [{
+        contentType: 'image/png',
         contentUrl: base64Photo
       }]
     };
@@ -31,7 +46,7 @@ class Carousel extends SkypeMessage {
     super();
 
     this.template = {
-      type: 'message/card.carousel',
+      type: 'message',
       attachmentLayout: 'carousel',
       summary: summary || '',
       text: text || '',
@@ -209,6 +224,7 @@ class Typing extends SkypeMessage {
 //TODO: investigate how to send Hero, Thumbnail and Receipt without carousel
 
 module.exports = {
+  Text: Text,
   Photo: Photo,
   Carousel: Carousel,
   Typing: Typing

--- a/lib/skype/reply.js
+++ b/lib/skype/reply.js
@@ -6,10 +6,12 @@ const retry = require('oh-no-i-insist');
 const retryTimeout = 500;
 const numRetries = 2;
 
-function sendReply(conversationId, message, contextId, authToken){
+function sendReply(conversationId, message, authToken, apiBaseUri, activityId){
+  apiBaseUri = apiBaseUri.replace(/\/$/, '');
+
   if (typeof message === 'string')
     message = {
-      type: 'message/text',
+      type: 'message',
       text: message
     };
 
@@ -21,17 +23,14 @@ function sendReply(conversationId, message, contextId, authToken){
     body: JSON.stringify(message)
   };
 
-  if (contextId){
-    options.headers['ContextId'] = contextId;
-  }
-  return rp.post(`https://apis.skype.com/v3/conversations/${conversationId}/activities`, options);
+  return rp.post(`${apiBaseUri}/v3/conversations/${conversationId}/activities/${activityId}`, options);
 }
 
-module.exports = function skReply(skypeAppId, skypePrivateKey, conversationId, message, contextId) {
+module.exports = function skReply(skypeAppId, skypePrivateKey, conversationId, message, apiBaseUri, activityId) {
   return retry(
     () => {
       return skBearerToken.getToken(skypeAppId, skypePrivateKey)
-      .then((token) => sendReply(conversationId, message, contextId, token));
+      .then((token) => sendReply(conversationId, message, token, apiBaseUri, activityId));
     },
     retryTimeout,
     numRetries,

--- a/lib/skype/setup.js
+++ b/lib/skype/setup.js
@@ -11,13 +11,12 @@ module.exports = function skSetup(api, bot, logError, optionalParser, optionalRe
 
 
   api.post('/skype', request => {
-    let arr = request.body instanceof Array ? [].concat.apply([], request.body) : [request.body],
-      skContextId = request.headers.contextid;
+    let arr = request.body instanceof Array ? [].concat.apply([], request.body) : [request.body];
 
     let skHandle = parsedMessage => {
       if (!parsedMessage) return;
       return Promise.resolve(parsedMessage).then(parsedMessage => bot(parsedMessage, request))
-        .then(botResponse => responder(request.env.skypeAppId, request.env.skypePrivateKey, parsedMessage.sender, botResponse, skContextId))
+        .then(botResponse => responder(request.env.skypeAppId, request.env.skypePrivateKey, parsedMessage.sender, botResponse, parsedMessage.originalRequest.serviceUrl, parsedMessage.originalRequest.id))
         .catch(logError);
     };
 

--- a/spec/skype/skype-format-message-spec.js
+++ b/spec/skype/skype-format-message-spec.js
@@ -8,6 +8,37 @@ describe('Skype format message', () => {
     expect(typeof formatMessage).toBe('object');
   });
 
+  describe('Text', () => {
+    it('should be a class', () => {
+      const message = new formatMessage.Text('foo');
+      expect(typeof formatMessage.Text).toBe('function');
+      expect(message instanceof formatMessage.Text).toBeTruthy();
+    });
+
+    it('should throw an error if text is not provided', () => {
+      expect(() => new formatMessage.Text()).toThrowError('Text is required for Skype Text template');
+      expect(() => new formatMessage.Text({foo: 'bar'})).toThrowError('Text is required for Skype Text template');
+    });
+
+    it('should generate a valid Skype template object with plain text default', () => {
+      const message = new formatMessage.Text('foo').get();
+      expect(message).toEqual({
+        type: 'message',
+        text: 'foo',
+        textFormat: 'plain'
+      });
+    });
+
+    it('should generate a valid Skype template object with explicit format set', () => {
+      const message = new formatMessage.Text('foo', 'markdown').get();
+      expect(message).toEqual({
+        type: 'message',
+        text: 'foo',
+        textFormat: 'markdown'
+      });
+    });
+  });
+
   describe('Photo', () => {
     it('should be a class', () => {
       const message = new formatMessage.Photo('foo');
@@ -22,9 +53,10 @@ describe('Skype format message', () => {
     it('should generate a valid Skype template object', () => {
       const message = new formatMessage.Photo('base_64_string').get();
       expect(message).toEqual({
-        type: 'message/image',
+        type: 'message',
         attachments: [
           {
+            contentType: 'image/png',
             contentUrl: 'base_64_string'
           }
         ]
@@ -42,7 +74,7 @@ describe('Skype format message', () => {
     it('should generate a valid Carousel template object', () => {
       const message = new formatMessage.Carousel('summary', 'text').get();
       expect(message).toEqual({
-        type: 'message/card.carousel',
+        type: 'message',
         attachmentLayout: 'carousel',
         summary: 'summary',
         text: 'text',
@@ -64,7 +96,7 @@ describe('Skype format message', () => {
           .addText('text')
         .get();
       expect(message).toEqual({
-        type: 'message/card.carousel',
+        type: 'message',
         attachmentLayout: 'carousel',
         summary: 'summary',
         text: 'text',
@@ -121,7 +153,7 @@ describe('Skype format message', () => {
           .addButton('title', 'value', 'imBack')
         .get();
       expect(message).toEqual({
-        type: 'message/card.carousel',
+        type: 'message',
         attachmentLayout: 'carousel',
         summary: 'summary',
         text: 'text',
@@ -156,7 +188,7 @@ describe('Skype format message', () => {
           .addText('text')
         .get();
       expect(message).toEqual({
-        type: 'message/card.carousel',
+        type: 'message',
         attachmentLayout: 'carousel',
         summary: 'summary',
         text: 'text',
@@ -181,7 +213,7 @@ describe('Skype format message', () => {
           .addText('text')
         .get();
       expect(message).toEqual({
-        type: 'message/card.carousel',
+        type: 'message',
         attachmentLayout: 'carousel',
         summary: 'summary',
         text: 'text',
@@ -211,7 +243,7 @@ describe('Skype format message', () => {
             .addItem('title', 'subtitle', 'text', 'price', 'quantity', 'image')
         .get();
       expect(message).toEqual({
-        type: 'message/card.carousel',
+        type: 'message',
         attachmentLayout: 'carousel',
         summary: 'summary',
         text: 'text',
@@ -250,7 +282,7 @@ describe('Skype format message', () => {
             .addFact('key', 'value')
         .get();
       expect(message).toEqual({
-        type: 'message/card.carousel',
+        type: 'message',
         attachmentLayout: 'carousel',
         summary: 'summary',
         text: 'text',


### PR DESCRIPTION
Since bot framework endpoint support markdown/XML, I replace original Skype endpoint with it.(https://github.com/claudiajs/claudia-bot-builder/compare/master...RPing:skype-reply-markdown#diff-e7fc292614c7b9e41d82f363d228f255R26)

ref:
https://docs.microsoft.com/en-us/bot-framework/rest-api/bot-framework-rest-connector-create-messages
https://docs.microsoft.com/en-us/bot-framework/rest-api/bot-framework-rest-connector-api-reference#base-uri