### PR TITLE
Support Telegram channel post updates

### DIFF
--- a/lib/telegram/parse.js
+++ b/lib/telegram/parse.js
@@ -32,4 +32,14 @@ module.exports = function(messageObject) {
       type: 'telegram'
     };
   }
+
+  if (messageObject && messageObject.channel_post && messageObject.channel_post.chat && messageObject.channel_post.chat.id ){
+    var channelPost = messageObject.channel_post;
+    return {
+      sender: channelPost.chat.id,
+      text: channelPost.text || '',
+      originalRequest: messageObject,
+      type: 'telegram'
+    };
+  }
 };

--- a/spec/telegram/telegram-parse-spec.js
+++ b/spec/telegram/telegram-parse-spec.js
@@ -23,6 +23,10 @@ describe('Telegram parse', () => {
     var msg = {callback_query: {message: {chat: {id: 'some123ChatId'}},data: 'someCallbackData'}};
     expect(parse(msg)).toEqual({ sender: 'some123ChatId', text: 'someCallbackData', originalRequest: msg, type: 'telegram'});
   });
+  it('returns a parsed object when messageObject contains a channel post', () => {
+    var msg = {channel_post: {chat: {id: 'some123ChatId'}, text: 'ello Telegram channel' }};
+    expect(parse(msg)).toEqual({ sender: 'some123ChatId', text: 'ello Telegram channel', originalRequest: msg, type: 'telegram'});
+  });
   it('sender field should be equal to actual user_id', () => {
     var msg = {
       update_id: 920742096,


### PR DESCRIPTION
We only need to parse `channel_post`object in addition to `message` to support post updates from channels 🙂 

Example of update object from a channel (channel service posts, broadcast posts)
```json
{
      "update_id": 195485045,
      "channel_post": {
        "message_id": 6,
        "chat": {
          "id": 123,
          "title": "Best Channel",
          "username": "bestchannel",
          "type": "channel"
        },
        "date": 1520153063,
        "text": "test"
      }
```