### PR TITLE
Add Function for Adding a Video From Attachment ID

### DIFF
--- a/lib/facebook/format-message.js
+++ b/lib/facebook/format-message.js
@@ -178,6 +178,24 @@ class Video extends FacebookTemplate {
   }
 }
 
+class VideoFromAttachment extends FacebookTemplate {
+  constructor(attachment_id) {
+    super();
+
+    if (!attachment_id || '') {
+      throw new Error('The attachment requires a valid attachment id as the first parameter');
+    }
+    this.template = {
+      attachment: {
+        type: 'video',
+        payload: {
+          attachment_id: attachment_id        
+        }
+      }
+    };
+  }
+}
+
 class File extends FacebookTemplate {
   constructor(url) {
     super();
@@ -1046,6 +1064,7 @@ module.exports = {
   Image: Image,
   Audio: Audio,
   Video: Video,
+  VideoFromAttachment: VideoFromAttachment,
   File: File,
   Generic: Generic,
   Button: Button,


### PR DESCRIPTION
	- facebook allows for you to upload a file and serve it from them
	- this function allows you to use a video from an attachment rather than trying to upload it from where ever it is hosted
	- this could save load times for all videos being served
