### PR TITLE
Facebook Messenger v3.2 Fix

### DIFF
--- a/lib/facebook/setup.js
+++ b/lib/facebook/setup.js
@@ -69,14 +69,14 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
             console.log(`\n\n${color.green}Facebook Messenger setup${color.reset}\n`);
             console.log(`\nFollowing info is required for the setup, for more info check the documentation.\n`);
             console.log(`\nYour webhook URL is: ${color.cyan}${lambdaDetails.apiUrl}/facebook${color.reset}\n`);
-            console.log(`Your verify token is: ${color.cyan}${token}${color.reset}\n`);
+            console.log(`   fda Your verify token is: ${color.cyan}${token}${color.reset}\n`);
 
             return prompt(['Facebook page access token', 'Facebook App Secret', 'Facebook Page ID']);
           })
           .then(results => {
             console.log('\n');
             pageAccessToken = results['Facebook page access token'];
-             pageID = results['Facebook Page ID'];
+            pageID = results['Facebook Page ID'];
             const deployment = {
               restApiId: lambdaDetails.apiId,
               stageName: lambdaDetails.alias,
@@ -85,8 +85,6 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
                 facebookAppSecret: results['Facebook App Secret']
               }
             };
-            console.log('https://graph.facebook.com/v3.2/${pageID}/subscribed_apps?subscribed_fields=["messages"]&access_token=${pageAccessToken}')
-
             if (!data.variables || (!data.variables.facebookAppSecret && !results['Facebook App Secret']))
               console.log(`\n${color.yellow}Deprecation warning:${color.reset} your bot is not using facebook validation. Please re-run with --configure-fb-bot to set it. This will become mandatory in the next major version. See https://github.com/claudiajs/claudia-bot-builder/blob/master/docs/API.md#message-verification for more information.\n`);
 

--- a/lib/facebook/setup.js
+++ b/lib/facebook/setup.js
@@ -47,7 +47,7 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
         stageName: lambdaDetails.alias
       }).then(data => {
         if (options['configure-fb-bot']) {
-          let token, pageAccessToken;
+          let token, pageAccessToken, pageID;
 
           return Promise.resolve().then(() => {
             if (data.variables && data.variables.facebookVerifyToken)
@@ -71,11 +71,12 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
             console.log(`\nYour webhook URL is: ${color.cyan}${lambdaDetails.apiUrl}/facebook${color.reset}\n`);
             console.log(`Your verify token is: ${color.cyan}${token}${color.reset}\n`);
 
-            return prompt(['Facebook page access token', 'Facebook App Secret']);
+            return prompt(['Facebook page access token', 'Facebook App Secret', 'Facebook Page ID']);
           })
           .then(results => {
             console.log('\n');
             pageAccessToken = results['Facebook page access token'];
+             pageID = results['Facebook Page ID'];
             const deployment = {
               restApiId: lambdaDetails.apiId,
               stageName: lambdaDetails.alias,
@@ -84,13 +85,14 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
                 facebookAppSecret: results['Facebook App Secret']
               }
             };
+            console.log('https://graph.facebook.com/v3.2/${pageID}/subscribed_apps?subscribed_fields=["messages"]&access_token=${pageAccessToken}')
 
             if (!data.variables || (!data.variables.facebookAppSecret && !results['Facebook App Secret']))
               console.log(`\n${color.yellow}Deprecation warning:${color.reset} your bot is not using facebook validation. Please re-run with --configure-fb-bot to set it. This will become mandatory in the next major version. See https://github.com/claudiajs/claudia-bot-builder/blob/master/docs/API.md#message-verification for more information.\n`);
 
             return utils.apiGatewayPromise.createDeploymentPromise(deployment);
           })
-          .then(() => rp.post(`https://graph.facebook.com/v2.6/me/subscribed_apps?access_token=${pageAccessToken}`));
+          .then(() => rp.post(`https://graph.facebook.com/v3.2/${pageID}/subscribed_apps?subscribed_fields=['messages']&access_token=${pageAccessToken}`));
         }
       });
     })


### PR DESCRIPTION
(I can add more information to a README PR for set up purposes). The main change here is that Facebook has changed the URL of the POST request you need in order to setup a FB messenger chat bot. You will recall that when setting up a Facebook app and creating the webhook, you had to subscribe to certain fields. All you need for the chatbot to function is the "messages" field. In v3.2 of the Facebook Graph API, you now had to explicitly send FB, in the POST request, what fields you were planning on subscribing to. That is why 'messages' is now hard-coded into line 95. This POST request also required that you put the "pageID" of the Facebook page your chatbot was going to message from (the same page you got your Page Access Token from). This is either available in the settings of your Facebook page, or by viewing the source of the Facebook page and looking for the variable called "pageID".

Another weird addition is that chatbots now require a permission called "manage_pages". You can't actually give your FB app and chatbot the manage_pages permission from the main developer console. Instead, you need to go to this link: https://developers.facebook.com/tools/explorer/?classic=0 and from there choose your page, and add a new permission of "manage_pages".
