### PR TITLE
Setup Facebook Messenger API ver 4.0

### DIFF
--- a/lib/facebook/setup.js
+++ b/lib/facebook/setup.js
@@ -97,7 +97,7 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
 
             return utils.apiGatewayPromise.createDeploymentPromise(deployment);
           })
-            .then(() => rp.post(`https://graph.facebook.com/v4.0/${pageId}/subscribed_apps?access_token=${pageAccessToken}&subscribed_fields=[${subscribedFields}]`));
+          .then(() => rp.post(`https://graph.facebook.com/v4.0/${pageId}/subscribed_apps?access_token=${pageAccessToken}&subscribed_fields=[${subscribedFields}]`));
         }
       });
     })

--- a/lib/facebook/setup.js
+++ b/lib/facebook/setup.js
@@ -47,7 +47,7 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
         stageName: lambdaDetails.alias
       }).then(data => {
         if (options['configure-fb-bot']) {
-          let token, pageAccessToken;
+          let token, pageAccessToken, pageId, subscribedFields;
 
           return Promise.resolve().then(() => {
             if (data.variables && data.variables.facebookVerifyToken)
@@ -71,11 +71,18 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
             console.log(`\nYour webhook URL is: ${color.cyan}${lambdaDetails.apiUrl}/facebook${color.reset}\n`);
             console.log(`Your verify token is: ${color.cyan}${token}${color.reset}\n`);
 
-            return prompt(['Facebook page access token', 'Facebook App Secret']);
+            return prompt([
+              'Facebook page access token',
+              'Facebook App Secret',
+              'Facebook page ID',
+              'Subscribed fields (comma separated with no spaces)'
+            ]);
           })
           .then(results => {
             console.log('\n');
             pageAccessToken = results['Facebook page access token'];
+            pageId = results['Facebook page ID'];
+            subscribedFields = results['Subscribed fields'].split(',').map(field => `'${field}'`).join(',');
             const deployment = {
               restApiId: lambdaDetails.apiId,
               stageName: lambdaDetails.alias,
@@ -90,7 +97,7 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
 
             return utils.apiGatewayPromise.createDeploymentPromise(deployment);
           })
-          .then(() => rp.post(`https://graph.facebook.com/v2.6/me/subscribed_apps?access_token=${pageAccessToken}`));
+            .then(() => rp.post(`https://graph.facebook.com/v4.0/${pageId}/subscribed_apps?access_token=${pageAccessToken}&subscribed_fields=[${subscribedFields}]`));
         }
       });
     })

--- a/lib/facebook/setup.js
+++ b/lib/facebook/setup.js
@@ -82,7 +82,7 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
             console.log('\n');
             pageAccessToken = results['Facebook page access token'];
             pageId = results['Facebook page ID'];
-            subscribedFields = results['Subscribed fields'].split(',').map(field => `'${field}'`).join(',');
+            subscribedFields = results['Subscribed fields (comma separated with no spaces)'].split(',').map(field => `'${field}'`).join(',');
             const deployment = {
               restApiId: lambdaDetails.apiId,
               stageName: lambdaDetails.alias,

--- a/lib/facebook/setup.js
+++ b/lib/facebook/setup.js
@@ -75,14 +75,14 @@ module.exports = function fbSetup(api, bot, logError, optionalParser, optionalRe
               'Facebook page access token',
               'Facebook App Secret',
               'Facebook page ID',
-              'Subscribed fields (comma separated with no spaces)'
+              'Subscribed fields (comma separated)'
             ]);
           })
           .then(results => {
             console.log('\n');
             pageAccessToken = results['Facebook page access token'];
             pageId = results['Facebook page ID'];
-            subscribedFields = results['Subscribed fields (comma separated with no spaces)'].split(',').map(field => `'${field}'`).join(',');
+            subscribedFields = results['Subscribed fields (comma separated)'].split(',').map(field => `'${field.trim()}'`).join(',');
             const deployment = {
               restApiId: lambdaDetails.apiId,
               stageName: lambdaDetails.alias,


### PR DESCRIPTION
Fixed to be able to setup Facebook Messenger with API v4.0.

It shows following prompt at `claudia create --configure-fb-bot` command.
We need two additional parameters, page ID and subscribed fields.

```
Facebook page access token: <YOUR_FB_PAGE_ACCESS_TOKEN>
Facebook App Secret: <YOUR_FB_APP_SECRET>
Facebook page ID: <YOUR_FB_PAGE_ID>
Subscribed fields (comma separated): messages, messaging_postbacks
```